### PR TITLE
Ensure vhost_net module is available

### DIFF
--- a/playbooks/rpc-12.0-playbook.yml
+++ b/playbooks/rpc-12.0-playbook.yml
@@ -28,6 +28,7 @@
         - colordiff
         - fping
         - moreutils
+        - linux-image-extra-virtual
 
     - name: Add Nodes Hosts File Entries (Long)
       lineinfile: dest=/etc/hosts line='{{ hostvars[item].ansible_eth2.ipv4.address }} {{ heat_stack_prefix|string }}-{{ item }}' insertafter=EOF state=present


### PR DESCRIPTION
This module is compiled as a module but not supplied with the -generic
kernel package. This commit adds the linux-image-extra-virtual package
which pulls in the correct version of the extra modules package.

Connects rcbops/u-suk-dev#273
