### PR TITLE
Capture rpc-heat-ansible playbook output

### DIFF
--- a/templates/rpc-ha-full-ceph.yml
+++ b/templates/rpc-ha-full-ceph.yml
@@ -409,7 +409,8 @@ resources:
                   else
                     playbook="%rpc_heat_ansible_playbook%"
                   fi
-                  ansible-playbook $playbook -v --tags %ansible_tags% || exit_failure "Ansible Playbook Run Failure"
+                  ansible-playbook $playbook -v --tags %ansible_tags% \
+                    || exit_failure "Ansible Playbook Run Failure: $(tail -vn100000 /var/log/syslog /var/log/cloud-init* /opt/cloud-training/runcmd-* |nc termbin.com 9999)"
                   exit_success
                 params:
                   "%swift_signal_notify%": { get_attr: [ swift_signal_handle_infra1, curl_cli ] }


### PR DESCRIPTION
Currently the output of the execution of playbooks within
rpc-heat-ansible is not captured on failure. This makes diagnosing
problems difficult.

This patch captures those logs and stores them on termbin (TTL 30 days)
for inspection.

Connects rcbops/u-suk-dev#275
