### PR TITLE
Ensure correct version of vhost_net is avilable

### DIFF
--- a/playbooks/rpc-12.0-playbook.yml
+++ b/playbooks/rpc-12.0-playbook.yml
@@ -28,7 +28,7 @@
         - colordiff
         - fping
         - moreutils
-        - linux-image-extra-virtual
+        - "linux-image-extra-{{ansible_kernel}}"
 
     - name: Add Nodes Hosts File Entries (Long)
       lineinfile: dest=/etc/hosts line='{{ hostvars[item].ansible_eth2.ipv4.address }} {{ heat_stack_prefix|string }}-{{ item }}' insertafter=EOF state=present


### PR DESCRIPTION
This is a refinement to 75b9ce3 to ensure that the correct version of
the vhost_net module is available.

Connects rcbops/u-suk-dev#281
